### PR TITLE
Half the docker image size. Show qrencode usage in docs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,15 @@ FROM python:2.7-alpine
 
 LABEL maintainer "Kayvan Sylvan <kayvansylvan@gmail.com>"
 
-RUN apk add --no-cache libxml2-dev libxslt-dev gcc libc-dev
-RUN pip install lxml oath PyCrypto requests
-
 COPY . /usr/src/
 WORKDIR /usr/src
-RUN pip install .
+
+RUN apk add --no-cache --virtual .build-deps \
+    gcc libc-dev libxml2-dev libxslt-dev \
+  && apk add --no-cache libxml2 libxslt \
+  && pip install --no-cache-dir lxml oath PyCrypto requests \
+  && pip install --no-cache-dir . \
+  && find /usr/local -name *.pyo -o -name *.pyc -exec rm -f '{}' \; \
+  && apk del .build-deps && touch /root/.vipaccess
+
 ENTRYPOINT ["/usr/local/bin/vipaccess"]

--- a/README.md
+++ b/README.md
@@ -60,19 +60,22 @@ If you have Docker installed, you can simply use the
 the `vipaccess` tool:
 
 ```
-docker run --rm kayvan/vipaccess -h
-usage: vipaccess [-h] {provision,show} ...
+docker run --rm kayvan/vipaccess provision -p -t VSST
+Credential created successfully:
+	otpauth://totp/VIP%20Access:VSST1113377?secret=YOURSECRET&issuer=Symantec
+This credential expires on this date: 2020-06-05T15:26:26.585Z
 
-positional arguments:
-  {provision,show}
-    provision       Provision a new VIP Access credential
-    show            Show the current 6-digit token
-
-optional arguments:
-  -h, --help        show this help message and exit
+You will need the ID to register this credential: VSST1113377
 ```
 
-Alternatively, you can build it.
+And with your generated secret, use the `show` command like this:
+
+```
+docker run --rm kayvan/vipaccess show -s YOURSECRET
+935163
+```
+
+Alternatively, you can build it:
 
 1. Check out this repository by running
    ``git clone https://github.com/dlenski/python-vipaccess.git``
@@ -137,6 +140,17 @@ secret AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 id VSST12345678
 expiry 2019-01-15T12:00:00.000Z
 ```
+
+### Using qrencode to register your credential with TOTP apps (e.g. Authy)
+
+Once you generate a token with `vipaccess provision -p`, use the `otpauth` URL
+to generate the QR code:
+
+```
+qrencode -t ANSI256 'otpauth://totp/VIP%20Access:VSSTXXXX?secret=YYYY&issuer=Symantec'
+```
+
+Scan the code into your TOTP generating app, like Authy.
 
 ### Generating access codes using an existing credential
 


### PR DESCRIPTION
Through some layer-reducing magic and judicious use of alpine package tools, I reduced the image size by half:

```
$ docker image ls
REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
new                    latest              ff196a3c00ee        23 minutes ago      90 MB
kayvan/vipaccess       latest              924c623acd94        15 hours ago        198 MB
```

See https://blog.replicated.com/engineering/refactoring-a-dockerfile-for-image-size/
and http://www.sandtable.com/reduce-docker-image-sizes-using-alpine/

Also added a quick mention of how to use the codes generated with TOTP apps like Authy.