### PR TITLE
Add initial hotp support, some code linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Main differences:
   version on the VIP Access tokens; as far as I can tell there is no
   real difference between them, but some clients require one or the
   other specifically.
+- Provision HOTP Tokens (`VSMB`)
 - Command-line utility is expanded to support *both* token
   provisioning (creating a new token) and emitting codes for an
   existing token (inspired by the command-line interface of
@@ -112,7 +113,7 @@ optional arguments:
                         ~/.vipaccess
   -t TOKEN_MODEL, --token-model TOKEN_MODEL
                         VIP Access token model. Should be VSST (desktop token,
-                        default) or VSMT (mobile token). Some clients only
+                        default) or VSMT (mobile token), VSMB for HOTP token. Some clients only
                         accept one or the other.
 ```
 
@@ -154,6 +155,17 @@ qrencode -t ANSI256 'otpauth://totp/VIP%20Access:VSSTXXXX?secret=YYYY&issuer=Sym
 
 Scan the code into your TOTP generating app, like Authy.
 
+
+### Using HOTP
+
+Use VSMB as token type `vipaccess provision -p -t VSMB`
+Known Limitations:
+* No way to re-synchronize if token ever gets out of sync with VIP Server.
+* You should use HEX code with Yubikeys
+* Tokens have an expiry date similar TOTP tokens unlike Yubikey VIP Tokens.
+* First try may not work as we used that token to validate it.
+
+
 ### Generating access codes using an existing credential
 
 The `vipaccess [show]` option will also do this for you: by default it
@@ -161,6 +173,7 @@ generates codes based on the credential in `~/.vipaccess`, but you can
 specify an alternative credential file or specify the OATH "token
 secret" on the command line.
 
+Cannot be used with hotp tokens as of now.
 ```
 usage: vipaccess show [-h] [-s SECRET | -f DOTFILE]
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
-from setuptools import setup
+#!/usr/bin/env python
+"""
+Setup vipaccess
+"""
 from io import open
+from setuptools import setup
 
 with open('README.md', encoding='utf-8') as f:
     readme = f.read()

--- a/vipaccess/cli.py
+++ b/vipaccess/cli.py
@@ -1,13 +1,18 @@
+#!/usr/bin/env python
+"""
+Cli tool to Access provision funcs
+"""
 from __future__ import print_function
 
-import os, sys
+import os
+import sys
 import argparse
 import oath
 import base64
 from vipaccess.patharg import PathType
 from vipaccess import provision as vp
 
-EXCL_WRITE = 'x' if sys.version_info>=(3,3) else 'wx'
+EXCL_WRITE = 'x' if sys.version_info>=(3, 3) else 'wx'
 
 # http://stackoverflow.com/a/26379693/20789
 
@@ -64,20 +69,29 @@ def provision(p, args):
         print('Credential created successfully:\n\t' + otp_uri)
         print("This credential expires on this date: " + otp_token['expiry'])
         print('\nYou will need the ID to register this credential: ' + otp_token['id'])
-        print('\nYou can use oathtool to generate the same OTP codes')
-        print('as would be produced by the official VIP Access apps:\n')
-        print('    oathtool -d6 -b --totp    {}  # 6-digit code'''.format(otp_secret_b32))
-        print('    oathtool -d6 -b --totp -v {}  # ... with extra information'''.format(otp_secret_b32))
+        if otp_token['id'].startswith('VSMB'):
+            otp_secret_hex = vp.decode_secret_hex(otp_secret)
+            print('Secret in HEX for Yubikey: '+ otp_secret_hex)
+        else:
+            print('\nYou can use oathtool to generate the same OTP codes')
+            print('as would be produced by the official VIP Access apps:\n')
+            print('    Token is Time based TOTP Token')
+            print('    oathtool -d6 -b --totp    {}  # 6-digit code'''.format(otp_secret_b32))
+            print('    oathtool -d6 -b --totp -v {}  # ... with extra information'''.format(otp_secret_b32))
     else:
-        assert otp_token['digits']==6
-        assert otp_token['algorithm']=='sha1'
-        assert otp_token['period']==30
+        assert otp_token['digits'] == 6
+        assert otp_token['algorithm'] == 'sha1'
+        if not otp_token['id'].startswith('VSMB'):
+            assert otp_token['period'] == 30
         os.umask(0o077) # stoken does this too (security)
         with open(os.path.expanduser(args.dotfile), EXCL_WRITE) as dotfile:
             dotfile.write('version 1\n')
             dotfile.write('secret %s\n' % otp_secret_b32)
             dotfile.write('id %s\n' % otp_token['id'])
             dotfile.write('expiry %s\n' % otp_token['expiry'])
+            if otp_token['id'].startswith('VSMB'):
+                # increase counter because we used 2 to test token
+                dotfile.write('count 2')
         print('Credential created and saved successfully: ' + dotfile.name)
         print('You will need the ID to register this credential: ' + otp_token['id'])
 
@@ -86,14 +100,19 @@ def show(p, args):
         secret = args.secret
     else:
         with open(args.dotfile, "r") as dotfile:
-            d = dict( l.strip().split(None, 1) for l in dotfile )
+            d = dict(l.strip().split(None, 1) for l in dotfile)
         if 'version' not in d:
             p.error('%s does not specify version' % args.dotfile)
         elif d['version'] != '1':
             p.error("%s specifies version %r, rather than expected '1'" % (args.dotfile, d['version']))
         elif 'secret' not in d:
             p.error('%s does not specify secret' % args.dotfile)
+        elif 'id' not in d:
+            p.error('%s does not contain and id' % args.dotfile)
+        if d.get('id').startswith('VSMB'):
+            p.error('HOTP token generation is not supported yet.')
         secret = d.get('secret')
+
         if args.verbose:
             if 'id' in d: print('Token ID: %s' % d['id'], file=sys.stderr)
             if 'expiry' in d: print('Token expiration: %s' % d['expiry'], file=sys.stderr)
@@ -118,11 +137,11 @@ def main():
     pprov.set_defaults(func=provision)
     m = pprov.add_mutually_exclusive_group()
     m.add_argument('-p', '--print', action=PrintAction, nargs=0,
-                   help="Print the new credential, but don't save it to a file")
+                    help="Print the new credential, but don't save it to a file")
     m.add_argument('-o', '--dotfile', type=PathType(type='file', exists=False), default=os.path.expanduser('~/.vipaccess'),
-                   help="File in which to store the new credential (default ~/.vipaccess")
-    pprov.add_argument('-t', '--token-model', default='VSST',
-                      help="VIP Access token model. Should be VSST (desktop token, default) or VSMT (mobile token). Some clients only accept one or the other.")
+                    help="File in which to store the new credential (default ~/.vipaccess")
+    pprov.add_argument('-t', '--token-model', default='VSMT',
+                    help="VIP Access token model. Should be VSST (desktop token, default) or VSMT (mobile token) or VSMB (HOTP). Some clients only accept one or the other.")
 
     pshow = sp.add_parser('show', help="Show the current 6-digit token")
     m = pshow.add_mutually_exclusive_group()
@@ -137,5 +156,5 @@ def main():
     args = p.parse_args()
     return args.func(p, args)
 
-if __name__=='__main__':
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
- Added HOTP  Support.
- For Yubikey the secret needs to be in hex
- Some linting to hush the linter a bit.
However It has following **limitations**. 
- No way to resync the tokens if it ever gets out of sync. afaik, token resync URL does not work for HOTP.
- Need to keep track of counter to use the cli to generate otp codes. But I guess its not necessary since most of the ppl who use cli to generate otp codes should be using totp anyway. HOTP is useful with hardware tokens.
- I am not sure from where VSMB reference was found. @darconeous 's fork has it. 

@dlenski  Perhaps you wish to ask @darconeous is okay with it? Is the upstream project dead?

I also created a Docker image to test : `tprasadtp/py-vipaccess:upstream-hotp`