### PR TITLE
Uppercase algorithm in generated URI

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,7 +84,7 @@ def test_generate_otp_uri():
         'timeskew': 0,
     }
     test_secret = b'ZqeD\xd9wg]"\x12\x1f7\xc7v6"\xf0\x13\\i'
-    expected_uri = urlparse.urlparse('otpauth://totp/VIP%20Access:VSST26070843?secret=LJYWKRGZO5TV2IQSD434O5RWELYBGXDJ&issuer=Symantec&digits=6&algorithm=sha1&period=30')
+    expected_uri = urlparse.urlparse('otpauth://totp/VIP%20Access:VSST26070843?secret=LJYWKRGZO5TV2IQSD434O5RWELYBGXDJ&issuer=Symantec&digits=6&algorithm=SHA1&period=30')
     generated_uri = urlparse.urlparse(generate_otp_uri(test_token, test_secret))
     assert generated_uri.scheme == expected_uri.scheme
     assert generated_uri.netloc == expected_uri.netloc

--- a/vipaccess/provision.py
+++ b/vipaccess/provision.py
@@ -176,7 +176,7 @@ def generate_otp_uri(token, secret):
             secret=secret,
             digits=token.get('digits', 6),
             period=token.get('period', 30),
-            algorithm=token.get('algorithm', 'sha1'),
+            algorithm=token.get('algorithm', 'SHA1').upper(),
             issuer='Symantec'
             )
         )


### PR DESCRIPTION
Google Authenticator (v3.0.0 on iOS 11.4.1) appears to reject as invalid QR codes generated from URIs with the algorithm in lowercase. Changing `algorithm=sha1` to `algorithm=SHA1` resolves the issue.

The Google Authenticator [wiki](https://github.com/google/google-authenticator/wiki/Key-Uri-Format#algorithm) shows the possible algorithm values as uppercase (then again, they also claim the algorithm parameter is ignored).