### PR TITLE
setup.cfg: Allow later versions of pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         'lxml==4.2.5',
         'oath>=1.4.1',
-        'pycryptodome==3.6.6',
+        'pycryptodome>=3.6.6',
         'requests',
     ],
     entry_points={


### PR DESCRIPTION
Some distributions (such as arch) ship versions of pycryptodome later than 3.6.6.